### PR TITLE
Add cube collision logic and UI improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,10 +31,12 @@ arena = Entity(
 # UI Elements
 score_text = Text("Score: 0", position=(-0.8, 0.45), scale=2, color=color.white)
 size_text = Text("Size: 1", position=(-0.8, 0.4), scale=2, color=color.white)
-leaderboard_text = Text("Leaderboard:", position=(0.5, 0.45), scale=1.5, color=color.white)
+leaderboard_text = Text("Leaderboard:", position=(0.55, 0.45), scale=1.5, color=color.white)
+game_over_text = Text("", position=(0,0), scale=3, color=color.red, origin=(0,0), enabled=False)
 
 # Local snake and camera controller
 def restart_game():
+    game_over_text.enabled = False
     for cube in collectible_cubes[:]:
         destroy(cube)
         collectible_cubes.remove(cube)
@@ -130,6 +132,9 @@ def update():
     if local_snake.alive:
         local_snake.update()
         local_snake.check_collision(ws_client.websocket)
+    else:
+        game_over_text.text = "GAME OVER"
+        game_over_text.enabled = True
     for snake in other_players.values():
         snake.update()
     all_snakes = [local_snake] + list(other_players.values())
@@ -138,6 +143,14 @@ def update():
     camera_controller.update()
     score_text.text = f"Score: {local_snake.score}"
     size_text.text = f"Size: {len(local_snake.segments)}"
+    # Leaderboard
+    players = [(local_snake.player_id, local_snake.score)] + [
+        (pid, s.score) for pid, s in other_players.items()
+    ]
+    players.sort(key=lambda x: x[1], reverse=True)
+    leaderboard_text.text = "Leaderboard:\n" + "\n".join(
+        f"{pid}: {score}" for pid, score in players
+    )
 
 # Start websocket in separate thread
 

--- a/snake2048/game/entities.py
+++ b/snake2048/game/entities.py
@@ -1,6 +1,12 @@
 from ursina import Entity, Text, color
 import random
 
+
+def choose_text_color(base_color):
+    """Pick black or white text based on brightness for readability."""
+    brightness = (base_color.r + base_color.g + base_color.b) / 3
+    return color.black if brightness > 0.5 else color.white
+
 class SnakeSegment(Entity):
     """Single segment of a snake with a numeric value."""
     def __init__(self, position=(0, 0, 0), value=2, player_color=color.blue):
@@ -14,7 +20,7 @@ class SnakeSegment(Entity):
         self.value = value
         self.text_entity = Text(
             text=str(self.value), parent=self, y=0.6, scale=10,
-            origin=(0, 0), color=color.white
+            origin=(0, 0), color=choose_text_color(self.color)
         )
 
 class CollectibleCube(Entity):
@@ -31,5 +37,5 @@ class CollectibleCube(Entity):
         self.cube_id = cube_id or random.randint(1000, 9999)
         self.text_entity = Text(
             text=str(self.value), parent=self, y=0.6, scale=10,
-            origin=(0, 0), color=color.white
+            origin=(0, 0), color=choose_text_color(self.color)
         )

--- a/snake2048/game/snake.py
+++ b/snake2048/game/snake.py
@@ -125,7 +125,10 @@ class Snake:
         if self.player_id == "local_player":
             for cube in collectible_cubes[:]:
                 if distance(self.head.position, cube.position) < 1.0:
-                    self.collect_cube(cube, websocket_client)
+                    if cube.value <= self.head.value:
+                        self.collect_cube(cube, websocket_client)
+                    else:
+                        self.die(websocket_client)
                     break
 
 def spawn_collectible_cube(position=None, value=None, cube_id=None):


### PR DESCRIPTION
## Summary
- improve readability of text on cubes
- kill player when hitting larger cubes
- show game over text when the player dies
- display dynamic leaderboard of all players

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68471fc1c28c8328b7f16914299db144