### PR TITLE
Fix asyncio usage for websocket messaging

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,7 +131,7 @@ setup_game()
 def update():
     if local_snake.alive:
         local_snake.update()
-        local_snake.check_collision(ws_client.websocket)
+        local_snake.check_collision(ws_client)
     else:
         game_over_text.text = "GAME OVER"
         game_over_text.enabled = True
@@ -139,7 +139,7 @@ def update():
         snake.update()
     all_snakes = [local_snake] + list(other_players.values())
     for snake in all_snakes:
-        snake.check_collision_with_other_snakes(all_snakes, ws_client.websocket)
+        snake.check_collision_with_other_snakes(all_snakes, ws_client)
     camera_controller.update()
     score_text.text = f"Score: {local_snake.score}"
     size_text.text = f"Size: {len(local_snake.segments)}"

--- a/snake2048/game/snake.py
+++ b/snake2048/game/snake.py
@@ -1,6 +1,4 @@
 from ursina import Vec3, destroy, distance, held_keys, color, time, invoke
-import asyncio
-import json
 import random
 from .entities import SnakeSegment, CollectibleCube
 
@@ -80,12 +78,8 @@ class Snake:
             self.grow(cube.value)
             collectible_cubes.remove(cube)
             destroy(cube)
-            if websocket_client and websocket_client.open:
-                asyncio.create_task(
-                    websocket_client.send(
-                        json.dumps({"type": "collect_cube", "cube_id": cube.cube_id})
-                    )
-                )
+            if websocket_client and websocket_client.websocket and websocket_client.websocket.open:
+                websocket_client.send_threadsafe({"type": "collect_cube", "cube_id": cube.cube_id})
         else:
             print("Cannot collect cube: value too high!")
 
@@ -105,10 +99,8 @@ class Snake:
 
     def die(self, websocket_client=None):
         self.alive = False
-        if websocket_client and websocket_client.open:
-            asyncio.create_task(
-                websocket_client.send(json.dumps({"type": "player_death", "id": self.player_id}))
-            )
+        if websocket_client and websocket_client.websocket and websocket_client.websocket.open:
+            websocket_client.send_threadsafe({"type": "player_death", "id": self.player_id})
         for segment in self.segments:
             segment.visible = False
         if self.player_id == "local_player":


### PR DESCRIPTION
## Summary
- ensure `WebSocketClient` keeps a running event loop
- add `send_threadsafe` helper for cross-thread calls
- use `send_threadsafe` from `Snake` logic
- pass the client object to collision checks rather than the raw websocket

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68474cc9680c8328a590a338cb506a2e